### PR TITLE
Configure lobby server settings

### DIFF
--- a/core/lobby/src/main/java/conexao/code/listeners/LobbySettingsListener.java
+++ b/core/lobby/src/main/java/conexao/code/listeners/LobbySettingsListener.java
@@ -1,0 +1,101 @@
+package conexao.code.listeners;
+
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class LobbySettingsListener implements Listener {
+    private static final ItemStack COMPASS;
+    private static final ItemStack SWORD;
+    static {
+        COMPASS = new ItemStack(Material.COMPASS);
+        ItemMeta cMeta = COMPASS.getItemMeta();
+        if (cMeta != null) {
+            cMeta.setUnbreakable(true);
+            COMPASS.setItemMeta(cMeta);
+        }
+        SWORD = new ItemStack(Material.WOODEN_SWORD);
+        ItemMeta sMeta = SWORD.getItemMeta();
+        if (sMeta != null) {
+            sMeta.setUnbreakable(true);
+            SWORD.setItemMeta(sMeta);
+        }
+    }
+
+    private void giveItems(Player p) {
+        p.getInventory().clear();
+        p.getInventory().setItem(0, COMPASS.clone());
+        p.getInventory().setItem(1, SWORD.clone());
+    }
+
+    private void applyPlayerSettings(Player p) {
+        p.setGameMode(GameMode.ADVENTURE);
+        p.setFoodLevel(20);
+        p.setMaxHealth(2.0);
+        p.setHealth(2.0);
+        p.setHealthScale(2.0);
+        p.setHealthScaled(true);
+        giveItems(p);
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent e) {
+        e.setJoinMessage(null);
+        applyPlayerSettings(e.getPlayer());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent e) {
+        e.setQuitMessage(null);
+    }
+
+    @EventHandler
+    public void onRespawn(PlayerRespawnEvent e) {
+        applyPlayerSettings(e.getPlayer());
+    }
+
+    @EventHandler
+    public void onFoodChange(FoodLevelChangeEvent e) {
+        if (e.getEntity() instanceof Player player) {
+            e.setCancelled(true);
+            player.setFoodLevel(20);
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent e) {
+        if (e.getEntity() instanceof Player) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onBreak(BlockBreakEvent e) {
+        e.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent e) {
+        Material type = e.getItemDrop().getItemStack().getType();
+        if (type == Material.COMPASS || type.toString().endsWith("_SWORD")) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onAdvancement(PlayerAdvancementDoneEvent e) {
+        e.message(null);
+    }
+}

--- a/core/lobby/src/main/java/conexao/code/lobby.java
+++ b/core/lobby/src/main/java/conexao/code/lobby.java
@@ -8,6 +8,7 @@ import conexao.code.common.DatabaseManager;
 import conexao.code.manager.ScoreboardManager;
 import conexao.code.manager.TabListManager;
 import conexao.code.manager.SpawnManager;
+import conexao.code.listeners.LobbySettingsListener;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -35,6 +36,7 @@ public class lobby extends JavaPlugin implements Listener {
         tabListManager.applyAll();
         spawnManager = new SpawnManager(this);
         Bukkit.getPluginManager().registerEvents(this, this);
+        Bukkit.getPluginManager().registerEvents(new LobbySettingsListener(), this);
         getCommand("recarregar").setExecutor(new ReloadCommand(this, scoreboardManager, tabListManager));
         getCommand("setspawn").setExecutor(new SetSpawnCommand(spawnManager));
         getCommand("trocarsenha").setExecutor(new ChangePasswordCommand(this));
@@ -47,6 +49,7 @@ public class lobby extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
+        e.setJoinMessage(null);
         e.getPlayer().setScoreboard(scoreboardManager.getBoard());
         tabListManager.applyAll();
         if (spawnManager.getSpawn() != null) {


### PR DESCRIPTION
## Summary
- spawn players with a compass and a wooden sword
- keep players in adventure mode with only one heart
- block item drops, block breaking, damage and hunger in the lobby
- suppress join, quit and advancement messages
- register the new listener in the lobby plugin

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685440753454832ea7ca3cb2d1467842