### PR TITLE
Add server selector compass to lobby

### DIFF
--- a/core/lobby/src/main/java/conexao/code/listeners/LobbySettingsListener.java
+++ b/core/lobby/src/main/java/conexao/code/listeners/LobbySettingsListener.java
@@ -2,6 +2,7 @@ package conexao.code.listeners;
 
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,26 +19,19 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 public class LobbySettingsListener implements Listener {
     private static final ItemStack COMPASS;
-    private static final ItemStack SWORD;
     static {
         COMPASS = new ItemStack(Material.COMPASS);
         ItemMeta cMeta = COMPASS.getItemMeta();
         if (cMeta != null) {
             cMeta.setUnbreakable(true);
+            cMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&aServidores"));
             COMPASS.setItemMeta(cMeta);
-        }
-        SWORD = new ItemStack(Material.WOODEN_SWORD);
-        ItemMeta sMeta = SWORD.getItemMeta();
-        if (sMeta != null) {
-            sMeta.setUnbreakable(true);
-            SWORD.setItemMeta(sMeta);
         }
     }
 
     private void giveItems(Player p) {
         p.getInventory().clear();
-        p.getInventory().setItem(0, COMPASS.clone());
-        p.getInventory().setItem(1, SWORD.clone());
+        p.getInventory().setItem(4, COMPASS.clone());
     }
 
     private void applyPlayerSettings(Player p) {
@@ -89,7 +83,7 @@ public class LobbySettingsListener implements Listener {
     @EventHandler
     public void onDrop(PlayerDropItemEvent e) {
         Material type = e.getItemDrop().getItemStack().getType();
-        if (type == Material.COMPASS || type.toString().endsWith("_SWORD")) {
+        if (type == Material.COMPASS) {
             e.setCancelled(true);
         }
     }

--- a/core/lobby/src/main/java/conexao/code/lobby.java
+++ b/core/lobby/src/main/java/conexao/code/lobby.java
@@ -9,6 +9,7 @@ import conexao.code.manager.ScoreboardManager;
 import conexao.code.manager.TabListManager;
 import conexao.code.manager.SpawnManager;
 import conexao.code.listeners.LobbySettingsListener;
+import conexao.code.menu.ServerSelectorMenu;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,6 +21,7 @@ public class lobby extends JavaPlugin implements Listener {
     private ScoreboardManager scoreboardManager;
     private TabListManager tabListManager;
     private SpawnManager spawnManager;
+    private ServerSelectorMenu selectorMenu;
 
     @Override
     public void onEnable() {
@@ -35,8 +37,11 @@ public class lobby extends JavaPlugin implements Listener {
         tabListManager = new TabListManager(this);
         tabListManager.applyAll();
         spawnManager = new SpawnManager(this);
+        selectorMenu = new ServerSelectorMenu(this);
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         Bukkit.getPluginManager().registerEvents(this, this);
         Bukkit.getPluginManager().registerEvents(new LobbySettingsListener(), this);
+        Bukkit.getPluginManager().registerEvents(selectorMenu, this);
         getCommand("recarregar").setExecutor(new ReloadCommand(this, scoreboardManager, tabListManager));
         getCommand("setspawn").setExecutor(new SetSpawnCommand(spawnManager));
         getCommand("trocarsenha").setExecutor(new ChangePasswordCommand(this));

--- a/core/lobby/src/main/java/conexao/code/menu/ServerSelectorMenu.java
+++ b/core/lobby/src/main/java/conexao/code/menu/ServerSelectorMenu.java
@@ -1,0 +1,104 @@
+package conexao.code.menu;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServerSelectorMenu implements Listener {
+    private final Plugin plugin;
+    private final Inventory menu;
+    private final Map<Integer, String> serverBySlot = new HashMap<>();
+
+    public ServerSelectorMenu(Plugin plugin) {
+        this.plugin = plugin;
+        this.menu = Bukkit.createInventory(null, 27, ChatColor.translateAlternateColorCodes('&', "&aServidores"));
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        serverBySlot.clear();
+        menu.clear();
+        FileConfiguration cfg = plugin.getConfig();
+        List<Map<?, ?>> servers = cfg.getMapList("servers");
+        for (Map<?, ?> map : servers) {
+            Object slotObj = map.get("slot");
+            Object itemObj = map.get("item");
+            Object nameObj = map.get("name");
+            Object loreObj = map.get("lore");
+            Object serverObj = map.get("server");
+            if (slotObj == null || itemObj == null || serverObj == null) continue;
+            int slot = (int) slotObj;
+            Material mat = Material.matchMaterial(String.valueOf(itemObj));
+            if (mat == null || slot < 0 || slot >= menu.getSize()) continue;
+            String name = nameObj != null ? String.valueOf(nameObj) : mat.name();
+            @SuppressWarnings("unchecked")
+            List<String> lore = loreObj instanceof List ? (List<String>) loreObj : List.of();
+            ItemStack item = new ItemStack(mat);
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+                List<String> cLore = new ArrayList<>();
+                for (String line : lore) {
+                    cLore.add(ChatColor.translateAlternateColorCodes('&', line));
+                }
+                meta.setLore(cLore);
+                item.setItemMeta(meta);
+            }
+            menu.setItem(slot, item);
+            serverBySlot.put(slot, String.valueOf(serverObj));
+        }
+    }
+
+    private void connect(Player player, String server) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF("Connect");
+        out.writeUTF(server);
+        player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+    }
+
+    public void open(Player player) {
+        player.openInventory(menu);
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent e) {
+        if (!e.hasItem()) return;
+        ItemStack stack = e.getItem();
+        if (stack.getType() != Material.COMPASS) return;
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) return;
+        if (ChatColor.translateAlternateColorCodes('&', "&aServidores").equals(meta.getDisplayName())) {
+            e.setCancelled(true);
+            open(e.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent e) {
+        if (!e.getView().getTopInventory().equals(menu)) return;
+        e.setCancelled(true);
+        int slot = e.getRawSlot();
+        String server = serverBySlot.get(slot);
+        if (server != null && e.getWhoClicked() instanceof Player p) {
+            p.closeInventory();
+            connect(p, server);
+        }
+    }
+}

--- a/core/lobby/src/main/resources/config.yml
+++ b/core/lobby/src/main/resources/config.yml
@@ -37,3 +37,18 @@ scoreboard:
 tablist:
   header: '&cCOMMUNITY'
   footer: '&8redecommunity.com'
+
+# ----- Servidores -----
+servers:
+  - slot: 11
+    item: DIAMOND_SWORD
+    name: '&cFactions'
+    lore:
+      - '&7Servidor focado em Factions'
+    server: factions
+  - slot: 15
+    item: GRASS_BLOCK
+    name: '&aSkyWars'
+    lore:
+      - '&7Entre em partidas rápidas de SkyWars'
+    server: skywars


### PR DESCRIPTION
## Summary
- give players a single compass named "&aServidores" instead of a sword
- server selector menu opens on right-click and connects via BungeeCord
- add example servers to `config.yml`

## Testing
- `gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6854c4812a8c832e9d1f30570a56724e