### PR TITLE
Remove server prefix from global chat

### DIFF
--- a/core/bungee/src/main/java/conexao/code/Bungee.java
+++ b/core/bungee/src/main/java/conexao/code/Bungee.java
@@ -57,7 +57,7 @@ public class Bungee extends Plugin implements Listener {
             ByteArrayDataInput in = ByteStreams.newDataInput(e.getData());
             String type = in.readUTF();
             if ("GLOBAL".equalsIgnoreCase(type)) {
-                String server = in.readUTF();
+                // O servidor de origem não é mais enviado pelo plugin de chat.
                 String name = in.readUTF();
                 String message = in.readUTF();
                 String targets = in.readUTF();

--- a/core/chat/src/main/java/conexao/code/ChatPlugin.java
+++ b/core/chat/src/main/java/conexao/code/ChatPlugin.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.util.List;
 
 public class ChatPlugin extends JavaPlugin implements Listener {
-    private String serverName;
     private double localRadius;
     private List<String> globalTargets;
 
@@ -23,7 +22,6 @@ public class ChatPlugin extends JavaPlugin implements Listener {
     public void onEnable() {
         saveDefaultConfig();
         FileConfiguration cfg = getConfig();
-        serverName = cfg.getString("server-name", "server");
         localRadius = cfg.getDouble("local-radius", 60.0);
         globalTargets = cfg.getStringList("global-servers");
 
@@ -60,7 +58,9 @@ public class ChatPlugin extends JavaPlugin implements Listener {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             DataOutputStream data = new DataOutputStream(out);
             data.writeUTF("GLOBAL");
-            data.writeUTF(serverName);
+            // Não enviamos mais o nome do servidor de origem, apenas o jogador
+            // e a mensagem, garantindo que o prefixo [G] seja o mesmo em todos
+            // os servidores.
             data.writeUTF(sender.getName());
             data.writeUTF(message);
             data.writeUTF(String.join(",", globalTargets));

--- a/core/chat/src/main/resources/config.yml
+++ b/core/chat/src/main/resources/config.yml
@@ -1,5 +1,3 @@
-# Nome deste servidor conforme definido no proxy
-server-name: factions
 # Raio do chat local. Defina 0 ou negativo para alcance ilimitado
 local-radius: 60
 # Servidores que receberão o chat global enviado deste servidor


### PR DESCRIPTION
## Summary
- adjust `ChatPlugin` so global chat messages don't send server name
- update proxy listener to match new message format
- clean up chat plugin config

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6854e1021504832eb40ff1c71b8c5dbf