### PR TITLE
Fix copy paths for Windows builds

### DIFF
--- a/core/bungee/build.gradle
+++ b/core/bungee/build.gradle
@@ -32,7 +32,8 @@ tasks.withType(JavaCompile).configureEach {
 tasks.register('copyPlugin', Copy) {
     dependsOn tasks.named('jar')
     from tasks.named('jar')
-    into new File('E\\hyze\\bungee\\plugins')
+    // Usa caminho absoluto no Windows
+    into new File('E:/hyze/bungee/plugins')
 }
 
 tasks.named('build') {

--- a/core/factions/build.gradle
+++ b/core/factions/build.gradle
@@ -62,7 +62,8 @@ processResources {
 tasks.register('copyPlugin', Copy) {
     dependsOn tasks.named('jar')
     from tasks.named('jar')
-    into new File('E\\hyze\\factions\\plugins')
+    // Caminho absoluto para E:\\ evita criar diret\u00f3rios locais
+    into new File('E:/hyze/factions/plugins')
 }
 
 tasks.named('build') {

--- a/core/lobby/build.gradle
+++ b/core/lobby/build.gradle
@@ -68,5 +68,6 @@ tasks.named('build') {
 tasks.register('copyPlugin', Copy) {
     dependsOn tasks.named('shadowJar')
     from tasks.named('shadowJar')
-    into new File('E\\hyze\\lobby\\plugins')
+    // Copia direto para a pasta do servidor (E:\\)
+    into new File('E:/hyze/lobby/plugins')
 }

--- a/core/loginserver/build.gradle
+++ b/core/loginserver/build.gradle
@@ -68,5 +68,6 @@ tasks.named('build') {
 tasks.register('copyPlugin', Copy) {
     dependsOn tasks.named('shadowJar')
     from tasks.named('shadowJar')
-    into new File('E\\hyze\\login\\plugins')
+    // Copia o plugin para a pasta do servidor de login em E:\\
+    into new File('E:/hyze/login/plugins')
 }


### PR DESCRIPTION
## Summary
- copy all plugin jars to absolute paths on Windows (E: drive)

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_6854e31bc6e8832e85c062b02323448a