### PR TITLE
Fix faction invite component and chat formatting

### DIFF
--- a/core/chat/src/main/java/conexao/code/ChatPlugin.java
+++ b/core/chat/src/main/java/conexao/code/ChatPlugin.java
@@ -11,6 +11,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import conexao.code.common.DatabaseManager;
 import conexao.code.common.factions.FactionMemberDAO;
 import conexao.code.common.factions.FactionRank;
+import java.util.Optional;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -74,9 +75,12 @@ public class ChatPlugin extends JavaPlugin implements Listener {
         String factionTag = null;
         String icon = "";
         try {
-            factionTag = FactionMemberDAO.getFactionTag(sender.getUniqueId()).orElse(null);
-            FactionRank rank = FactionMemberDAO.getRank(sender.getUniqueId()).orElse(null);
-            if (rank != null) icon = rank.getIcon();
+            Optional<String> tagOpt = FactionMemberDAO.getFactionTag(sender.getUniqueId());
+            if (tagOpt.isPresent()) {
+                factionTag = tagOpt.get();
+                FactionRank rank = FactionMemberDAO.getRank(sender.getUniqueId()).orElse(null);
+                if (rank != null) icon = rank.getIcon();
+            }
         } catch (Exception ignored) {}
         if (factionTag != null) {
             formatted = ChatColor.GRAY + "[L] " + ChatColor.GRAY + "[" + icon + " " + factionTag + "] " + sender.getDisplayName() + ChatColor.GRAY + ": " + ChatColor.GRAY + message;
@@ -100,9 +104,12 @@ public class ChatPlugin extends JavaPlugin implements Listener {
         String factionTag = null;
         String icon = "";
         try {
-            factionTag = FactionMemberDAO.getFactionTag(sender.getUniqueId()).orElse(null);
-            FactionRank rank = FactionMemberDAO.getRank(sender.getUniqueId()).orElse(null);
-            if (rank != null) icon = rank.getIcon();
+            Optional<String> tagOpt = FactionMemberDAO.getFactionTag(sender.getUniqueId());
+            if (tagOpt.isPresent()) {
+                factionTag = tagOpt.get();
+                FactionRank rank = FactionMemberDAO.getRank(sender.getUniqueId()).orElse(null);
+                if (rank != null) icon = rank.getIcon();
+            }
         } catch (Exception ignored) {}
         String formatted;
         if (factionTag != null) {

--- a/factions-plugin/src/main/java/conexao/code/factionsplugin/FactionCommand.java
+++ b/factions-plugin/src/main/java/conexao/code/factionsplugin/FactionCommand.java
@@ -13,6 +13,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.util.Map;
 import java.util.UUID;
@@ -131,13 +132,18 @@ public class FactionCommand implements CommandExecutor {
             }
             FactionsPlugin.Invite invite = new FactionsPlugin.Invite(factionId, player.getUniqueId(), now + 5 * 60_000L);
             invites.put(target.getUniqueId(), invite);
-            TextComponent accept = Component.text(ChatColor.GREEN + "[Sim]")
+            TextComponent accept = Component.text("[Sim]", NamedTextColor.GREEN)
                     .clickEvent(ClickEvent.runCommand("/f aceitar"));
-            TextComponent deny = Component.text(ChatColor.RED + "[Não]")
+            TextComponent deny = Component.text("[Não]", NamedTextColor.RED)
                     .clickEvent(ClickEvent.runCommand("/nao"));
             target.sendMessage(ChatColor.YELLOW + "Facção " + FactionDAO.getTagById(factionId).orElse("") + " te convidou");
             target.sendMessage(ChatColor.YELLOW + "Deseja aceitar?");
-            target.spigot().sendMessage(accept, Component.text(" "), deny);
+            Component message = Component.text()
+                    .append(accept)
+                    .append(Component.space())
+                    .append(deny)
+                    .build();
+            target.sendMessage(message);
             player.sendMessage(ChatColor.GREEN + "Convite enviado para " + target.getName());
         } catch (Exception e) {
             player.sendMessage(ChatColor.RED + "Erro ao convidar jogador.");


### PR DESCRIPTION
## Summary
- fix clickable invite components using Adventure API
- handle missing faction properly when formatting chat messages

## Testing
- `sh core/gradlew build`
- `sh ../core/gradlew build` inside factions-plugin

------
https://chatgpt.com/codex/tasks/task_e_6855dc180408832e99d9d82e74587e9c