### PR TITLE
Corrige duplicação de tag no chat

### DIFF
--- a/core/chat/src/main/java/conexao/code/ChatPlugin.java
+++ b/core/chat/src/main/java/conexao/code/ChatPlugin.java
@@ -113,11 +113,15 @@ public class ChatPlugin extends JavaPlugin implements Listener {
             }
         } catch (Exception ignored) {}
         String formatted;
+        String remoteName;
         if (factionTag != null) {
             String name = stripFactionSuffix(sender.getDisplayName(), icon, factionTag);
-            formatted = ChatColor.GRAY + "[G] " + ChatColor.GRAY + "[" + icon + factionTag + "] " + name + ChatColor.GRAY + ": " + ChatColor.RESET + message;
+            String prefix = ChatColor.GRAY + "[" + icon + factionTag + "] " + name;
+            formatted = ChatColor.GRAY + "[G] " + prefix + ChatColor.GRAY + ": " + ChatColor.RESET + message;
+            remoteName = prefix;
         } else {
             formatted = ChatColor.GRAY + "[G] " + sender.getDisplayName() + ChatColor.GRAY + ": " + ChatColor.RESET + message;
+            remoteName = sender.getDisplayName();
         }
         for (Player p : Bukkit.getOnlinePlayers()) {
             p.sendMessage(formatted);
@@ -129,7 +133,7 @@ public class ChatPlugin extends JavaPlugin implements Listener {
             // Não enviamos mais o nome do servidor de origem, apenas o jogador
             // e a mensagem, garantindo que o prefixo [G] seja o mesmo em todos
             // os servidores.
-            data.writeUTF(sender.getDisplayName());
+            data.writeUTF(remoteName);
             data.writeUTF(message);
 
             List<String> targets = globalTargets;

--- a/core/permissions/src/main/java/conexao/code/permissionsplugin/TagManager.java
+++ b/core/permissions/src/main/java/conexao/code/permissionsplugin/TagManager.java
@@ -21,8 +21,13 @@ public class TagManager {
     }
 
     public void apply(Player player, Tag tag, String factionTag, String icon, boolean showFaction) {
+        // Nome base sem a tag da facção, utilizado no chat
+        String base = format(tag, player, null, "", false);
+        // Nome completo (com facção) mostrado na lista de jogadores e acima do personagem
         String full = format(tag, player, factionTag, icon, showFaction);
-        player.setDisplayName(full);
+
+        // Evita a repetição da tag da facção no chat usando apenas o nome base
+        player.setDisplayName(base);
         player.setPlayerListName(full);
         player.setCustomName(full);
         player.setCustomNameVisible(true);


### PR DESCRIPTION
## Summary
- evita duplicação da tag de facção no chat
- envia nome formatado corretamente no global

## Testing
- `sh gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_685714749e94832ea127388c65aee62f