### PR TITLE
Implement fixed lobby hologram

### DIFF
--- a/core/lobby/src/main/java/conexao/code/commands/SetHologramCommand.java
+++ b/core/lobby/src/main/java/conexao/code/commands/SetHologramCommand.java
@@ -1,0 +1,43 @@
+package conexao.code.commands;
+
+import conexao.code.hologram.HologramManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+public class SetHologramCommand implements CommandExecutor {
+    private final Plugin plugin;
+    private final HologramManager hologramManager;
+
+    public SetHologramCommand(Plugin plugin, HologramManager manager) {
+        this.plugin = plugin;
+        this.hologramManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Comando apenas para jogadores.");
+            return true;
+        }
+        if (!sender.hasPermission("lobby.sethologram")) {
+            sender.sendMessage(ChatColor.RED + "Você não tem permissão para isso.");
+            return true;
+        }
+        Location loc = player.getLocation();
+        plugin.getConfig().set("hologram.world", loc.getWorld().getName());
+        plugin.getConfig().set("hologram.x", loc.getX());
+        plugin.getConfig().set("hologram.y", loc.getY());
+        plugin.getConfig().set("hologram.z", loc.getZ());
+        plugin.saveConfig();
+        if (hologramManager != null) {
+            hologramManager.setLocation(loc);
+        }
+        sender.sendMessage(ChatColor.GREEN + "Holograma definido!");
+        return true;
+    }
+}

--- a/core/lobby/src/main/java/conexao/code/hologram/HologramManager.java
+++ b/core/lobby/src/main/java/conexao/code/hologram/HologramManager.java
@@ -4,19 +4,13 @@ import conexao.code.manager.ScoreboardManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class HologramManager implements Listener {
     private final Plugin plugin;
@@ -24,92 +18,79 @@ public class HologramManager implements Listener {
     private final ItemStack item;
     private final String server;
     private final double offsetY;
-    private final Map<Player, Hologram> active = new HashMap<>();
+    private final boolean smallItem;
+    private final String nameColor;
+    private final String countColor;
+    private Location location;
 
-    public HologramManager(Plugin plugin, ScoreboardManager scoreboardManager, ItemStack item, String server, double offsetY) {
+    private ArmorStand itemStand;
+    private ArmorStand nameStand;
+    private ArmorStand countStand;
+    private BukkitTask task;
+
+    public HologramManager(Plugin plugin, ScoreboardManager scoreboardManager, ItemStack item,
+                           String server, double offsetY, boolean smallItem,
+                           String nameColor, String countColor, Location loc) {
         this.plugin = plugin;
         this.scoreboardManager = scoreboardManager;
         this.item = item;
         this.server = server;
         this.offsetY = offsetY;
+        this.smallItem = smallItem;
+        this.nameColor = nameColor;
+        this.countColor = countColor;
+        this.location = loc;
         Bukkit.getPluginManager().registerEvents(this, plugin);
+        if (loc != null) spawn();
     }
 
-    public void removeAll() {
-        for (Hologram h : active.values()) {
-            h.destroy();
-        }
-        active.clear();
+    public void setLocation(Location loc) {
+        remove();
+        this.location = loc;
+        if (loc != null) spawn();
     }
 
-    @EventHandler
-    public void onJoin(PlayerJoinEvent e) {
-        spawnFor(e.getPlayer());
+    public void remove() {
+        if (task != null) task.cancel();
+        if (itemStand != null) itemStand.remove();
+        if (nameStand != null) nameStand.remove();
+        if (countStand != null) countStand.remove();
+        task = null;
+        itemStand = nameStand = countStand = null;
     }
 
-    @EventHandler
-    public void onQuit(PlayerQuitEvent e) {
-        remove(e.getPlayer());
+    private void spawn() {
+        Location base = location.clone().add(0, offsetY, 0);
+        itemStand = spawnStand(base, false);
+        itemStand.setSmall(smallItem);
+        itemStand.getEquipment().setItem(EquipmentSlot.HEAD, item);
+
+        nameStand = spawnStand(base.clone().add(0, 0.4, 0), true);
+        nameStand.setCustomName(ChatColor.translateAlternateColorCodes('&', nameColor + server));
+
+        countStand = spawnStand(base.clone().add(0, -0.4, 0), true);
+
+        task = Bukkit.getScheduler().runTaskTimer(plugin, this::update, 0L, 20L);
     }
 
-    private void spawnFor(Player player) {
-        Hologram h = new Hologram(player);
-        active.put(player, h);
+    private ArmorStand spawnStand(Location loc, boolean customName) {
+        World world = loc.getWorld();
+        ArmorStand as = world.spawn(loc, ArmorStand.class);
+        as.setInvisible(true);
+        as.setMarker(true);
+        as.setGravity(false);
+        as.setCustomNameVisible(customName);
+        return as;
     }
 
-    private void remove(Player player) {
-        Hologram h = active.remove(player);
-        if (h != null) {
-            h.destroy();
-        }
-    }
-
-    private class Hologram {
-        private final Player player;
-        private final ArmorStand itemStand;
-        private final ArmorStand nameStand;
-        private final ArmorStand countStand;
-        private final BukkitTask task;
-
-        Hologram(Player p) {
-            this.player = p;
-            Location loc = p.getLocation().add(0, offsetY, 0);
-            itemStand = spawn(loc, false);
-            itemStand.getEquipment().setItem(EquipmentSlot.HEAD, item);
-
-            nameStand = spawn(loc.clone().add(0, 0.4, 0), true);
-            nameStand.setCustomName(ChatColor.translateAlternateColorCodes('&', server));
-
-            countStand = spawn(loc.clone().add(0, -0.4, 0), true);
-
-            task = Bukkit.getScheduler().runTaskTimer(plugin, this::update, 0L, 2L);
-        }
-
-        private ArmorStand spawn(Location loc, boolean customName) {
-            ArmorStand as = loc.getWorld().spawn(loc, ArmorStand.class);
-            as.setInvisible(true);
-            as.setMarker(true);
-            as.setGravity(false);
-            as.setCustomNameVisible(customName);
-            return as;
-        }
-
-        private void update() {
-            Location base = player.getLocation().add(0, offsetY, 0);
-            itemStand.teleport(base);
-            itemStand.setRotation(itemStand.getLocation().getYaw() + 5f, 0f);
-            nameStand.teleport(base.clone().add(0, 0.4, 0));
-            countStand.teleport(base.clone().add(0, -0.4, 0));
-            int count = scoreboardManager.getPlayerCount(server);
-            scoreboardManager.requestPlayerCount(server);
-            countStand.setCustomName(ChatColor.YELLOW.toString() + count + " jogadores");
-        }
-
-        private void destroy() {
-            task.cancel();
-            itemStand.remove();
-            nameStand.remove();
-            countStand.remove();
-        }
+    private void update() {
+        Location base = location.clone().add(0, offsetY, 0);
+        itemStand.teleport(base);
+        itemStand.setRotation(itemStand.getLocation().getYaw() + 5f, 0f);
+        nameStand.teleport(base.clone().add(0, 0.4, 0));
+        countStand.teleport(base.clone().add(0, -0.4, 0));
+        int count = scoreboardManager.getPlayerCount(server);
+        scoreboardManager.requestPlayerCount(server);
+        countStand.setCustomName(ChatColor.translateAlternateColorCodes('&', countColor + count + " jogadores"));
     }
 }

--- a/core/lobby/src/main/resources/config.yml
+++ b/core/lobby/src/main/resources/config.yml
@@ -62,3 +62,11 @@ hologram:
   item: DIAMOND_SWORD
   server: factions
   offset-y: 2.0
+  small-item: false
+  name-color: '&e'
+  count-color: '&e'
+  # Defina usando /sethologram
+  world: world
+  x: 0
+  y: 80
+  z: 0

--- a/core/lobby/src/main/resources/plugin.yml
+++ b/core/lobby/src/main/resources/plugin.yml
@@ -14,10 +14,16 @@ commands:
   trocarsenha:
     description: Altera sua senha
     usage: /trocarsenha <senha-antiga> <senha-nova>
+  sethologram:
+    description: Define a localização do holograma do lobby
+    usage: /sethologram
 permissions:
   lobby.reload:
     description: Permite usar /recarregar
     default: op
   lobby.setspawn:
     description: Permite definir o spawn do lobby
+    default: op
+  lobby.sethologram:
+    description: Permite definir a posição do holograma
     default: op


### PR DESCRIPTION
## Summary
- add `/sethologram` command
- spawn lobby hologram at saved location
- allow customizing item size and hologram text colors
- update config and plugin.yml entries

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_685714c0ea64832ea24992c79d77981b